### PR TITLE
Move lib_extra_dirs to env section where PlatformIO expects it

### DIFF
--- a/t5/platformio_t5.ini
+++ b/t5/platformio_t5.ini
@@ -10,14 +10,16 @@
 [platformio]
 src_dir = t5/src
 include_dir = t5/include
-; Shared library for data managers, MQTT, WiFi, time
-lib_extra_dirs = shared
 
 [env:t5-epaper]
 
 platform = espressif32@ 6.9.0
 board = esp32-s3-devkitc-1
 framework = arduino
+
+; Shared library for data managers, MQTT, WiFi, time
+; Path relative to project root (where pio is invoked from)
+lib_extra_dirs = shared
 
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio


### PR DESCRIPTION
lib_extra_dirs is an env-level option, not a [platformio] section option. Moved to [env:t5-epaper] with a comment clarifying the path resolution.

https://claude.ai/code/session_016MizVFgogRcXJtH6XZZcHa